### PR TITLE
[BUGFIX] Prevent exception on usage reports, allow file extension

### DIFF
--- a/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
+++ b/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
@@ -54,11 +54,23 @@ class QbankSelectorButtonContainer extends InlineControlContainer
             return '';
         }
 
-        $this->addJavaScriptConfiguration();
+        try {
+            $accessToken = QbankUtility::getAccessToken();
+        } catch (\Throwable $th) {
+            return '';
+        }
+
+        $this->addJavaScriptConfiguration($accessToken);
         $this->javaScriptLocalization();
 
         $allowed
             = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
+        $allowedArray = GeneralUtility::trimExplode(',', $allowed, true);
+        if (empty($allowedArray)) {
+            $allowedArray = GeneralUtility::trimExplode(',', $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], true);
+        }
+        $allowed = implode(',', $allowedArray);
+
         $currentStructureDomObjectIdPrefix = $this->inlineStackProcessor->getCurrentStructureDomObjectIdPrefix(
             $this->data['inlineFirstPid']
         );
@@ -74,7 +86,7 @@ class QbankSelectorButtonContainer extends InlineControlContainer
                 data-title="' . htmlspecialchars($titleText) . '"
                 data-file-irre-object="' . htmlspecialchars($objectPrefix) . '"
                 data-file-allowed="' . htmlspecialchars($allowed) . '"
-                data-qbank-token="' . QbankUtility::getAccessToken() . '"
+                data-qbank-token="' . $accessToken . '"
                 disabled
                 >
                 ' . $this->iconFactory->getIcon('tx-qbank-logo', Icon::SIZE_SMALL)->render() . '
@@ -109,14 +121,15 @@ class QbankSelectorButtonContainer extends InlineControlContainer
      *
      *   token - The qbank access token
      *
+     * @param string $accessToken
      * @return void
      */
-    protected function addJavaScriptConfiguration(): void
+    protected function addJavaScriptConfiguration(string $accessToken): void
     {
         $extensionConfigurationManager = $this->getExtensionConfigurationManager();
 
         $configuration = [
-            'token' => QbankUtility::getAccessToken(),
+            'token' => $accessToken,
             'host' => $extensionConfigurationManager->getHost(),
             'deploymentSites' => $extensionConfigurationManager->getDeploymentSites(),
         ];

--- a/Classes/Service/QbankService.php
+++ b/Classes/Service/QbankService.php
@@ -210,6 +210,11 @@ class QbankService implements SingletonInterface
             new FileReferenceUrlEvent($fileReference, $this)
         )->getUrl() ?? '';
 
+        // No FileReferenceUrlEvent generated usage for file.
+        if ($url === '') {
+            return;
+        }
+
         $this->reportMediaUsage(
             $file->getUid(),
             $url,


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Skip QBank report media usage if no url could be resolved for file.

Add fallback to $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
when elementBrowserAllowed isn't set in TCA configuration for a field, to
allow e.g jpg files from QBank for page resources.

Resolves: #5
Resolves: #7
