### PR TITLE
[TASK] Add qbank-specific configuration of allowed extensions

### DIFF
--- a/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
+++ b/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
@@ -64,9 +64,9 @@ class QbankSelectorButtonContainer extends InlineControlContainer
         $this->javaScriptLocalization();
 
         $appearanceConfiguration = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance'];
-        
+
         $allowed = $appearanceConfiguration['qbankBrowserAllowed'] ?? $appearanceConfiguration['elementBrowserAllowed'];
-        
+
         $allowedArray = GeneralUtility::trimExplode(',', $allowed, true);
         if (empty($allowedArray)) {
             $allowedArray = GeneralUtility::trimExplode(',', $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], true);

--- a/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
+++ b/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
@@ -63,9 +63,10 @@ class QbankSelectorButtonContainer extends InlineControlContainer
         $this->addJavaScriptConfiguration($accessToken);
         $this->javaScriptLocalization();
 
-        $allowed
-            = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['qbankBrowserAllowed'] ??
-            $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
+        $appearanceConfiguration = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance'];
+        
+        $allowed = $appearanceConfiguration['qbankBrowserAllowed'] ?? $appearanceConfiguration['elementBrowserAllowed'];
+        
         $allowedArray = GeneralUtility::trimExplode(',', $allowed, true);
         if (empty($allowedArray)) {
             $allowedArray = GeneralUtility::trimExplode(',', $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], true);

--- a/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
+++ b/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
@@ -64,7 +64,8 @@ class QbankSelectorButtonContainer extends InlineControlContainer
         $this->javaScriptLocalization();
 
         $allowed
-            = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
+            = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['qbankBrowserAllowed']
+            ?? $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
         $allowedArray = GeneralUtility::trimExplode(',', $allowed, true);
         if (empty($allowedArray)) {
             $allowedArray = GeneralUtility::trimExplode(',', $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], true);

--- a/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
+++ b/Classes/FormEngine/Container/QbankSelectorButtonContainer.php
@@ -64,8 +64,8 @@ class QbankSelectorButtonContainer extends InlineControlContainer
         $this->javaScriptLocalization();
 
         $allowed
-            = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['qbankBrowserAllowed']
-            ?? $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
+            = $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['qbankBrowserAllowed'] ??
+            $inlineConfiguration['selectorOrUniqueConfiguration']['config']['appearance']['elementBrowserAllowed'];
         $allowedArray = GeneralUtility::trimExplode(',', $allowed, true);
         if (empty($allowedArray)) {
             $allowedArray = GeneralUtility::trimExplode(',', $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'], true);


### PR DESCRIPTION
# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description

Adds the configuration option `qbankBrowserAllowed` (similar to TYPO3 core's `elementBrowserAllowed`) for configuration of allowed file extensions per field in TCA.
