### PR TITLE
[BUGFIX] catch API exception to prevent Scheduler error

### DIFF
--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -217,7 +217,17 @@ final class ManagementController
             ->setModuleName('file_qbank')
             ->setGetVariables(['action', 'extension'])
             ->setDisplayName($this->shortcutName);
+
         $buttonBar->addButton($shortcutButton);
+
+        $reloadButton = $buttonBar->makeLinkButton()
+            ->setHref(GeneralUtility::getIndpEnv('REQUEST_URI'))
+            ->setTitle(
+                $this->getLanguageService()
+                    ->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.reload')
+            )
+            ->setIcon($this->iconFactory->getIcon('actions-refresh', Icon::SIZE_SMALL));
+        $buttonBar->addButton($reloadButton, ButtonBar::BUTTON_POSITION_RIGHT);
     }
 
     /**
@@ -265,7 +275,15 @@ final class ManagementController
                 continue;
             }
 
-            $this->qbankService->synchronizeMetadata($file);
+            try {
+                $this->qbankService->synchronizeMetadata($file);
+            } catch (\TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException $th) {
+                $this->moduleTemplate->addFlashMessage(
+                    $th->getMessage(),
+                    '',
+                    FlashMessage::ERROR
+                );
+            }
         }
 
         $this->moduleTemplate->addFlashMessage(

--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -221,12 +221,13 @@ final class ManagementController
         $buttonBar->addButton($shortcutButton);
 
         $reloadButton = $buttonBar->makeLinkButton()
-            ->setHref(GeneralUtility::getIndpEnv('REQUEST_URI'))
+            ->setHref($this->request->getAttribute('normalizedParams')->getRequestUri())
             ->setTitle(
                 $this->getLanguageService()
                     ->sL('LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.reload')
             )
             ->setIcon($this->iconFactory->getIcon('actions-refresh', Icon::SIZE_SMALL));
+
         $buttonBar->addButton($reloadButton, ButtonBar::BUTTON_POSITION_RIGHT);
     }
 
@@ -277,7 +278,7 @@ final class ManagementController
 
             try {
                 $this->qbankService->synchronizeMetadata($file);
-            } catch (\TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException $th) {
+            } catch (\Pixelant\Qbank\Exception\MediaPermanentlyDeletedException $th) {
                 $this->moduleTemplate->addFlashMessage(
                     $th->getMessage(),
                     '',

--- a/Classes/Exception/MediaPermanentlyDeletedException.php
+++ b/Classes/Exception/MediaPermanentlyDeletedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pixelant\Qbank\Exception;
+
+/**
+ * Exception thrown if a QBank media is permanently deleted.
+ */
+class MediaPermanentlyDeletedException extends \RuntimeException
+{
+}

--- a/Classes/Repository/QbankFileRepository.php
+++ b/Classes/Repository/QbankFileRepository.php
@@ -31,6 +31,7 @@ class QbankFileRepository
             'sys_file.tx_qbank_status_updated_timestamp',
             'sys_file.tx_qbank_remote_replaced_by',
             'sys_file.tx_qbank_remote_is_replaced',
+            'sys_file.tx_qbank_remote_is_deleted',
             'sys_file_metadata.uid AS metadata_uid',
         ];
 
@@ -91,6 +92,12 @@ class QbankFileRepository
                     $queryBuilder->createNamedParameter(time() - $interval, \PDO::PARAM_INT)
                 )
             )
+            ->andWhere(
+                $queryBuilder->expr()->eq(
+                    'sys_file.tx_qbank_remote_is_deleted',
+                    $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                )
+            )
             ->setMaxResults($limit)
             ->orderBy('sys_file.tx_qbank_status_updated_timestamp')
             ->execute();
@@ -118,6 +125,12 @@ class QbankFileRepository
             ->where(
                 $queryBuilder->expr()->gt(
                     'sys_file.tx_qbank_id',
+                    $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                )
+            )
+            ->andWhere(
+                $queryBuilder->expr()->eq(
+                    'sys_file.tx_qbank_remote_is_deleted',
                     $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
                 )
             )

--- a/Classes/Service/QbankService.php
+++ b/Classes/Service/QbankService.php
@@ -226,7 +226,7 @@ class QbankService implements SingletonInterface
      * Synchronize metadata for a particular file UID.
      *
      * @param int $fileId The FAL file UID
-     * @throws \TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException
+     * @throws \Pixelant\Qbank\Exception\MediaPermanentlyDeletedException
      */
     public function synchronizeMetadata(int $fileId): void
     {
@@ -243,7 +243,7 @@ class QbankService implements SingletonInterface
             if (QbankUtility::qbankRequestExceptionStatesMediaIsDeleted($re)) {
                 $this->updateFileRemoteIsDeleted($fileId);
 
-                throw new \TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException(
+                throw new \Pixelant\Qbank\Exception\MediaPermanentlyDeletedException(
                     'QBank Media is permanently deleted',
                     1625149218
                 );

--- a/Classes/Utility/QbankUtility.php
+++ b/Classes/Utility/QbankUtility.php
@@ -6,6 +6,7 @@ namespace Pixelant\Qbank\Utility;
 
 use Pixelant\Qbank\Configuration\ExtensionConfigurationManager;
 use QBNK\QBank\API\Credentials;
+use QBNK\QBank\API\Exception\RequestException;
 use QBNK\QBank\API\QBankApi;
 use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
@@ -163,5 +164,20 @@ class QbankUtility
         $extensionConfigurationManager = self::getConfigurationManager();
 
         return $extensionConfigurationManager->getAutoUpdate();
+    }
+
+    /**
+     * Returns true if request exception seems to be due to that the media is permanently deleted in QBank.
+     *
+     * @param RequestException $re
+     * @return bool
+     */
+    public static function qbankRequestExceptionStatesMediaIsDeleted(RequestException $re): bool
+    {
+        if (strpos(strtolower($re->getMessage()), 'media is permanently deleted') > 0) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -98,6 +98,9 @@
 			<trans-unit id="be.local_media_replaced" resname="be.local_media_replaced">
 				<source>Local media is replaced</source>
 			</trans-unit>
+			<trans-unit id="be.remote_deleted" resname="be.remote_deleted">
+				<source>Remote media is deleted</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Management/List.html
+++ b/Resources/Private/Templates/Management/List.html
@@ -35,6 +35,10 @@
                 <f:for each="{qbankFiles}" as="qbankFile">
                     <tr>
                         <td>
+                            <f:if condition="{qbankFile.tx_qbank_remote_is_deleted}">
+                                <f:then><core:icon identifier="tx-qbank-logo" overlay="overlay-missing" size="small" /></f:then>
+                                <f:else><core:icon identifier="tx-qbank-logo" size="small" /></f:else>
+                            </f:if>
                             <be:link.editRecord returnUrl="{returnUrl}" table="sys_file" uid="{qbankFile.uid}" title="{f:translate(key: 'LLL:EXT:core/Resources/Private/Language/locallang_mod_web_list.xlf:edit')}: {qbankFile.name} [{qbankFile.uid}, {qbankFile.tx_qbank_id}]">
                                 {qbankFile.name}
                             </be:link.editRecord>
@@ -86,23 +90,29 @@
                                     <core:icon identifier="actions-document-info" />
                             </a>
 
-                            <f:be.link
-                                route="file_qbank"
-                                parameters="{action: 'synchronizeMetadata', file: qbankFile.uid}"
-                                title="{f:translate(key: 'be.action.update-metadata')}"
-                                class="btn btn-success"
-                            >
-                                <core:icon identifier="actions-database-reload" /> {f:translate(key: 'be.action.update-metadata')}
-                            </f:be.link>
+                            <f:if condition="{qbankFile.tx_qbank_remote_is_deleted}">
+                                <f:then>
+                                    <core:icon identifier="actions-delete" />
+                                    <f:translate key="LLL:EXT:qbank/Resources/Private/Language/locallang.xlf:be.remote_deleted"/> ({qbankFile.tx_qbank_id})
+                                </f:then>
+                                <f:else>
+                                    <f:be.link
+                                        route="file_qbank"
+                                        parameters="{action: 'synchronizeMetadata', file: qbankFile.uid}"
+                                        title="{f:translate(key: 'be.action.update-metadata')}"
+                                        class="btn btn-success">
+                                        <core:icon identifier="actions-database-reload" /> {f:translate(key: 'be.action.update-metadata')}
+                                    </f:be.link>
 
-                            <f:be.link
-                                route="file_qbank"
-                                parameters="{action: 'replaceLocalMedia', file: qbankFile.uid}"
-                                title="{f:translate(key: 'be.action.update-file')}"
-                                class="btn btn-warning {f:if(condition: '{qbankFile.tx_qbank_remote_replaced_by}', then: '', else: 'disabled')} {f:if(condition: '{qbankFile.tx_qbank_remote_is_replaced}', then: 'disabled')}"
-                            >
-                                <core:icon identifier="actions-database-reload" /> {f:translate(key: 'be.action.update-file')}
-                            </f:be.link>
+                                    <f:be.link
+                                        route="file_qbank"
+                                        parameters="{action: 'replaceLocalMedia', file: qbankFile.uid}"
+                                        title="{f:translate(key: 'be.action.update-file')}"
+                                        class="btn btn-warning {f:if(condition: '{qbankFile.tx_qbank_remote_replaced_by}', then: '', else: 'disabled')} {f:if(condition: '{qbankFile.tx_qbank_remote_is_replaced}', then: 'disabled')}">
+                                        <core:icon identifier="actions-database-reload" /> {f:translate(key: 'be.action.update-file')}
+                                    </f:be.link>
+                                </f:else>
+                            </f:if>
                         </td>
                     </tr>
                 </f:for>

--- a/Tests/Unit/Utility/QbankUtilityTest.php
+++ b/Tests/Unit/Utility/QbankUtilityTest.php
@@ -74,7 +74,7 @@ class QbankUtilityTest extends UnitTestCase
     /**
      * @test
      */
-    public function qbankRequestExceptionStatesMediaIsDeletedReturnsFalseWhenMessageDoesntContainsCertainText(): void
+    public function qbankRequestExceptionStatesMediaIsDeletedReturnsFalseWhenMessageDoesntContainCertainText(): void
     {
         $re = new RequestException('Bad Request: Media could not be found.', 400, new \Exception());
 

--- a/Tests/Unit/Utility/QbankUtilityTest.php
+++ b/Tests/Unit/Utility/QbankUtilityTest.php
@@ -6,6 +6,7 @@ namespace Pixelant\Qbank\Unit\Utility;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use Pixelant\Qbank\Utility\QbankUtility;
+use QBNK\QBank\API\Exception\RequestException;
 
 /**
  * Test case.
@@ -55,6 +56,30 @@ class QbankUtilityTest extends UnitTestCase
         self::assertSame(
             QbankUtility::qbankDateStringToUnixTimestamp($stringDate),
             $testDateTime->getTimestamp()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function qbankRequestExceptionStatesMediaIsDeletedReturnsTrueWhenMessageContainsCertainText(): void
+    {
+        $re = new RequestException('Bad Request: Media is permanently deleted.', 400, new \Exception());
+
+        self::assertTrue(
+            QbankUtility::qbankRequestExceptionStatesMediaIsDeleted($re)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function qbankRequestExceptionStatesMediaIsDeletedReturnsFalseWhenMessageDoesntContainsCertainText(): void
+    {
+        $re = new RequestException('Bad Request: Media could not be found.', 400, new \Exception());
+
+        self::assertFalse(
+            QbankUtility::qbankRequestExceptionStatesMediaIsDeleted($re)
         );
     }
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE sys_file (
 	tx_qbank_remote_change_timestamp int(11) unsigned DEFAULT 0 NOT NULL,
 	tx_qbank_remote_replaced_by int(11) unsigned DEFAULT 0 NOT NULL,
 	tx_qbank_remote_is_replaced tinyint(3) unsigned DEFAULT 0 NOT NULL,
+	tx_qbank_remote_is_deleted tinyint(3) unsigned DEFAULT 0 NOT NULL,
 
 	KEY qbank (tx_qbank_id),
 );


### PR DESCRIPTION
Adds a new status "remote is deleted" field for sys_file table, so need to Analyze Database.
If exception is thrown when fetching media from API, this field will set to true.
This will prevent file from beeing processed in any of the conslole commands.
Also sync buttons in backend module will be removed.

Fixes #18.

# New Pull Request checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
